### PR TITLE
Fix MD copy background

### DIFF
--- a/md.html
+++ b/md.html
@@ -19,7 +19,8 @@
         }
 
         .container {
-            max-width: 100%;
+            max-width: 680px;
+            width: 100%;
             margin: 0 auto;
             background: white;
             border-radius: 12px;
@@ -558,7 +559,7 @@
             const htmlContent = marked.parse(markdownText);
             
             // 创建带样式的HTML内容
-            const styledHtml = `<div class="theme-${currentTheme}" style="font-family: -apple-system-font, BlinkMacSystemFont, 'Helvetica Neue', 'PingFang SC', 'Hiragino Sans GB', 'Microsoft YaHei UI', 'Microsoft YaHei', Arial, sans-serif; line-height: 1.8; color: #333;">${htmlContent}</div>`;
+            const styledHtml = `<div class="theme-${currentTheme}" style="font-family: -apple-system-font, BlinkMacSystemFont, 'Helvetica Neue', 'PingFang SC', 'Hiragino Sans GB', 'Microsoft YaHei UI', 'Microsoft YaHei', Arial, sans-serif; line-height: 1.8; color: #333; background:#ffffff;">${htmlContent}</div>`;
             
             copyContent.innerHTML = styledHtml;
             


### PR DESCRIPTION
## Summary
- adjust container width so desktop layout matches mobile
- include white background when copying styled HTML to WeChat

## Testing
- `npm test` *(fails: Could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6870891047648324bdc84837045f72ce